### PR TITLE
supp batt and can stuff

### DIFF
--- a/firmware/Rear-VCU/user/inc/can.hpp
+++ b/firmware/Rear-VCU/user/inc/can.hpp
@@ -6,7 +6,7 @@ extern FDCAN_HandleTypeDef hfdcan1;
 inline sg::CANDevice can_device(
     &hfdcan1);  // inline on variable declared in header file like this allows
                 // us to avoid odr when including in multiple cpp files, all references to it
-                // will correctly refer to a single instance of the variable.
+                // will correctly refer to this single instance of the variable.
 
 constexpr sg::CANFrame mitsuba_frame0_request = {
     .can_id = 0x08F89540,

--- a/firmware/Rear-VCU/user/inc/rearvcu_state.h
+++ b/firmware/Rear-VCU/user/inc/rearvcu_state.h
@@ -34,9 +34,6 @@ struct VCUState
     std::atomic<bool> array_contactors_requested_closed{};
     std::atomic<Direction> direction_requested{};
     std::atomic<MCPowerMode> mc_power_mode_requested{};
-
-    std::atomic<uint32_t> can_messages_received{};
-    std::atomic<uint32_t> can_messages_sent{};
 };
 
 inline VCUState vcu_state;

--- a/firmware/Rear-VCU/user/src/can.cpp
+++ b/firmware/Rear-VCU/user/src/can.cpp
@@ -36,8 +36,6 @@ HAL_StatusTypeDef throttleMessageCallback(const sg::CANFrame& msg, void* ctx)
         (static_cast<uint16_t>(throttle_high) << 8) | static_cast<uint16_t>(throttle_low);
     vcu_state.throttle_requested.store(throttle_value);
 
-    ++vcu_state.can_messages_received;
-
     return HAL_OK;
 }
 
@@ -47,8 +45,6 @@ HAL_StatusTypeDef driverMessageCallback(const sg::CANFrame& msg, void* ctx)
     vcu_state.array_contactors_requested_closed.store(static_cast<bool>(msg.data[2]));
     vcu_state.regen_requested.store(msg.data[5]);
     vcu_state.mc_power_mode_requested.store(static_cast<MCPowerMode>(msg.data[6]));
-
-    ++vcu_state.can_messages_received;
 
     return HAL_OK;
 }
@@ -77,8 +73,6 @@ HAL_StatusTypeDef mitsubaFrame0Callback(const sg::CANFrame& msg, void* ctx)
 
     vcu_state.car_speed.store(static_cast<uint8_t>(std::round(miles_per_hour)));
 
-    ++vcu_state.can_messages_received;
-
     return HAL_OK;
 }
 
@@ -97,5 +91,5 @@ void can_init()
         0x08850225, sg::CANFrameIDType::EXTENDED, &mitsubaFrame0Callback, nullptr));
 
     // start
-    ASSERT_HAL_OK(can_device.StartCANDevice());
+    ASSERT_HAL_OK(can_device.startCANDevice());
 }

--- a/firmware/Rear-VCU/user/src/user_threads.cpp
+++ b/firmware/Rear-VCU/user/src/user_threads.cpp
@@ -47,16 +47,31 @@ void init_user()
 
 [[noreturn]] void startHeartbeatTask_user(void* argument)
 {
+    sg::CANFrame supp_batt_frame{0x021,
+                                 sg::CANFrameIDType::STANDARD,
+                                 sg::CANFrameRTRMode::DATA,
+                                 sg::CANFrameLen::BYTES_4,
+                                 0,
+                                 {}};
+
     for (;;)
     {
         // blink ok led
         HAL_GPIO_TogglePin(OK_LED_GPIO_Port, OK_LED_Pin);
 
         // send mitsuba request for frame0 to get wheel rpm, shouldnt be sent faster than every 500ms
-        can_device.Send(mitsuba_frame0_request);
-        ++vcu_state.can_messages_sent;
+        can_device.send(mitsuba_frame0_request);
 
-        osDelay(550);
+        // supp batt voltage can be read and sent in this thread as its not as urgent/important
+        uint16_t supp_batt_voltage_mv = 0xFFFF;  // TODO: could get voltage of supp batt here
+        uint16_t supp_batt_current = 0xFFFF;     // TODO: could get current draw of supp batt here
+        supp_batt_frame.data[0] = static_cast<uint8_t>(supp_batt_voltage_mv);       // lsb
+        supp_batt_frame.data[1] = static_cast<uint8_t>(supp_batt_voltage_mv >> 8);  // msb
+        supp_batt_frame.data[2] = static_cast<uint8_t>(supp_batt_current);          // lsb
+        supp_batt_frame.data[3] = static_cast<uint8_t>(supp_batt_current >> 8);     // msb
+        can_device.send(supp_batt_frame);
+
+        osDelay(500);
     }
 }
 
@@ -83,7 +98,7 @@ void init_user()
     sg::CANFrame rearvcu_statuses_frame{0x020,
                                         sg::CANFrameIDType::STANDARD,
                                         sg::CANFrameRTRMode::DATA,
-                                        sg::CANFrameLen::BYTES_16,
+                                        sg::CANFrameLen::BYTES_8,
                                         0,
                                         {}};
 
@@ -132,24 +147,14 @@ void init_user()
             array_contactors = ArrayContactors::BOTH_OPEN;
         }
 
-        // TODO: could get voltage of supp batt here
-        uint16_t supp_batt_voltage_mv = 0x0F0F;  // dummy
-
-        // TODO: could get current draw of supp batt here
-        uint16_t supp_batt_current = 0x0F0F;  // dummy
-
         // setup and send diagnostic can message
         rearvcu_statuses_frame.data[0] =
             1;  // mc enable should always be enabled if this board is alive, written to at startup
         rearvcu_statuses_frame.data[1] = static_cast<uint8_t>(direction_requested);
         rearvcu_statuses_frame.data[2] = static_cast<uint8_t>(mc_power_mode_requested);
         rearvcu_statuses_frame.data[3] = static_cast<uint8_t>(array_contactors);
-        rearvcu_statuses_frame.data[4] = static_cast<uint8_t>(supp_batt_voltage_mv);       // lsb
-        rearvcu_statuses_frame.data[5] = static_cast<uint8_t>(supp_batt_voltage_mv >> 8);  // msb
-        rearvcu_statuses_frame.data[6] = static_cast<uint8_t>(supp_batt_current);          // lsb
-        rearvcu_statuses_frame.data[7] = static_cast<uint8_t>(supp_batt_current >> 8);     // msb
-        rearvcu_statuses_frame.data[8] = vcu_state.car_speed.load();
-        can_device.Send(rearvcu_statuses_frame);
+        rearvcu_statuses_frame.data[4] = vcu_state.car_speed.load();
+        can_device.send(rearvcu_statuses_frame);
 
         osDelay(200);
     }

--- a/firmware/Steering-Wheel/user/inc/steering_state.h
+++ b/firmware/Steering-Wheel/user/inc/steering_state.h
@@ -47,9 +47,6 @@ struct SteeringState
     std::atomic<uint8_t> car_speed{};
     std::atomic<ArrayContactors> array_contactors_status{};
     std::atomic<uint16_t> supp_batt_voltage{};
-
-    std::atomic<uint32_t> can_messages_received{};
-    std::atomic<uint32_t> can_messages_sent{};
 };
 
 inline SteeringState steering_state;

--- a/firmware/Steering-Wheel/user/src/can.cpp
+++ b/firmware/Steering-Wheel/user/src/can.cpp
@@ -17,7 +17,7 @@ void can_init()
     // recieve message from rear vcu
     ASSERT_TRUE(can_device.addCallbackId(
         0x020, sg::CANFrameIDType::STANDARD, &rearVCUInfoMessageCallback, nullptr));
-    ASSERT_HAL_OK(can_device.StartCANDevice());
+    ASSERT_HAL_OK(can_device.startCANDevice());
 }
 
 HAL_StatusTypeDef rearVCUInfoMessageCallback(const sg::CANFrame& msg, void* ctx)
@@ -28,8 +28,6 @@ HAL_StatusTypeDef rearVCUInfoMessageCallback(const sg::CANFrame& msg, void* ctx)
     steering_state.supp_batt_voltage.store(supp_batt_voltage);
 
     steering_state.car_speed.store(msg.data[8]);
-
-    ++steering_state.can_messages_received;
 
     return HAL_OK;
 }

--- a/firmware/Steering-Wheel/user/src/user_threads.cpp
+++ b/firmware/Steering-Wheel/user/src/user_threads.cpp
@@ -39,44 +39,48 @@ void startScreenTask_user(void* argument)
 
 void startPollButtons_user(void* argument)
 {
-    sg::CANFrame frame{0x064,
-                       sg::CANFrameIDType::STANDARD,
-                       sg::CANFrameRTRMode::DATA,
-                       sg::CANFrameLen::BYTES_8,
-                       0,
-                       {}};
+    sg::CANFrame steering_requests_frame{0x064,
+                                         sg::CANFrameIDType::STANDARD,
+                                         sg::CANFrameRTRMode::DATA,
+                                         sg::CANFrameLen::BYTES_8,
+                                         0,
+                                         {}};
 
     initButtons();
 
     for (;;)
     {
         // turn signals
-        frame.data[0] = static_cast<uint8_t>(steering_state.turn_signals_requested.load());
+        steering_requests_frame.data[0] =
+            static_cast<uint8_t>(steering_state.turn_signals_requested.load());
 
         // frwrd / reverse
-        frame.data[1] = static_cast<uint8_t>(steering_state.direction_requested.load());
+        steering_requests_frame.data[1] =
+            static_cast<uint8_t>(steering_state.direction_requested.load());
 
         // array
-        frame.data[2] =
+        steering_requests_frame.data[2] =
             static_cast<uint8_t>(steering_state.array_contactors_requested_closed.load());
 
         // horn
-        frame.data[3] = static_cast<uint8_t>(!HAL_GPIO_ReadPin(HORN_PORT, HORN_PIN));
+        steering_requests_frame.data[3] =
+            static_cast<uint8_t>(!HAL_GPIO_ReadPin(HORN_PORT, HORN_PIN));
 
         // headlights
-        frame.data[4] = static_cast<uint8_t>(steering_state.headlights_requested_on.load());
+        steering_requests_frame.data[4] =
+            static_cast<uint8_t>(steering_state.headlights_requested_on.load());
 
         // regen breaking strength
-        frame.data[5] = 0;
+        steering_requests_frame.data[5] = 0;
 
         // pwr/eco request
-        frame.data[6] = static_cast<uint8_t>(steering_state.mc_power_mode_requested.load());
+        steering_requests_frame.data[6] =
+            static_cast<uint8_t>(steering_state.mc_power_mode_requested.load());
 
         // cc mph
-        frame.data[7] = 0;
+        steering_requests_frame.data[7] = 0;
 
-        if (can_device.Send(frame) == HAL_OK)
-            ++steering_state.can_messages_sent;
+        can_device.send(steering_requests_frame);
 
         osDelay(20);
     }

--- a/firmware/Telemetry/user/src/can.cpp
+++ b/firmware/Telemetry/user/src/can.cpp
@@ -16,7 +16,7 @@ void can_init()
         can_device.addCallbackId(0x064, sg::CANFrameIDType::STANDARD, &steeringRequestsCallback));
     ASSERT_TRUE(
         can_device.addCallbackId(0x020, sg::CANFrameIDType::STANDARD, &rearVCUStatusCallback));
-    ASSERT_HAL_OK(can_device.StartCANDevice());
+    ASSERT_HAL_OK(can_device.startCANDevice());
 }
 
 HAL_StatusTypeDef steeringRequestsCallback(const sg::CANFrame& frame, void* ctx)

--- a/resources/Drivers/SG_Drivers/CAN/Include/CanDriver.hpp
+++ b/resources/Drivers/SG_Drivers/CAN/Include/CanDriver.hpp
@@ -12,6 +12,7 @@
 #include "CanDriverApi.hpp"
 #include "FreeRTOS.h"
 
+#include <atomic>
 #include <vector>
 
 namespace sg
@@ -103,7 +104,7 @@ class CANDevice
      *
      * @return HAL_OK on success, or an appropriate HAL error/status code if startup fails.
      */
-    HAL_StatusTypeDef StartCANDevice();
+    HAL_StatusTypeDef startCANDevice();
 
     /*!
      * @brief Adds a hardware filter to accept a single CAN identifier.
@@ -121,7 +122,7 @@ class CANDevice
      *
      * @return HAL_OK if the filter was successfully added, or an error/status code if not.
      */
-    HAL_StatusTypeDef AddFilterId(uint32_t can_id,
+    HAL_StatusTypeDef addFilterId(uint32_t can_id,
                                   CANFrameIDType id_type,
                                   CANFrameRTRMode rtr_mode,
                                   CANFramePriority priority);
@@ -145,7 +146,7 @@ class CANDevice
      *
      * @return HAL_OK if the filter was successfully added, or an error/status code if not.
      */
-    HAL_StatusTypeDef AddFilterRange(uint32_t can_id,
+    HAL_StatusTypeDef addFilterRange(uint32_t can_id,
                                      uint32_t range,
                                      sg::CANFrameIDType id_type,
                                      sg::CANFrameRTRMode rtr_mode,
@@ -206,7 +207,22 @@ class CANDevice
      * @param msg message to be sent, CANDevice stores a copy of it in a buffer
      * @return HAL error code, HAL_OK if pushed to queue successfully
      */
-    HAL_StatusTypeDef Send(const CANFrame& msg);
+    HAL_StatusTypeDef send(const CANFrame& msg);
+
+    // returns the total number of messages that have been recieved and processed (ie a callback was called on it) by the device
+    uint32_t getProcessedMessagesCount()
+    {
+        return processed_messages_count_.load(std::memory_order_relaxed);
+    }
+
+    // returns the total number of messages that have been sent by the device (ie added to a tx mailbox)
+    uint32_t getSentMessagesCount() { return sent_messages_count_.load(std::memory_order_relaxed); }
+
+    // returns total number of frames that were dropped by the device because when trying to push frame when recieved in isr the queue was full
+    uint32_t getDroppedFrameCount()
+    {
+        return dropped_rx_frame_count_.load(std::memory_order_relaxed);
+    }
 
     // should be unused by user
     static HAL_StatusTypeDef RxCallback(CanHandle_t* hcan);
@@ -229,6 +245,11 @@ class CANDevice
 
     osMessageQueueId_t tx_queue_;
     osMessageQueueId_t rx_queue_;
+
+    std::atomic<uint32_t>
+        processed_messages_count_{};               // number of messages a callback was called on
+    std::atomic<uint32_t> sent_messages_count_{};  // count of messages added to mailbox to be sent
+    std::atomic<uint32_t> dropped_rx_frame_count_{};  // count of dropped rx frames
 
     struct Entry
     {

--- a/resources/Drivers/SG_Drivers/CAN/Src/CanDriver.cpp
+++ b/resources/Drivers/SG_Drivers/CAN/Src/CanDriver.cpp
@@ -175,7 +175,7 @@ CANDevice::CANDevice(CanHandle_t* hcan)
     rangeCallbacks_.reserve(NUM_CAN_CALLBACKS);
 }
 
-HAL_StatusTypeDef CANDevice::StartCANDevice()
+HAL_StatusTypeDef CANDevice::startCANDevice()
 {
     if (!registerHandle(hcan_, this))
     {
@@ -286,7 +286,7 @@ HAL_StatusTypeDef CANDevice::StartCANDevice()
     return HAL_OK;
 }
 
-HAL_StatusTypeDef CANDevice::AddFilterId(uint32_t can_id,
+HAL_StatusTypeDef CANDevice::addFilterId(uint32_t can_id,
                                          CANFrameIDType id_type,
                                          CANFrameRTRMode rtr_mode,
                                          CANFramePriority priority)
@@ -396,7 +396,7 @@ HAL_StatusTypeDef CANDevice::AddFilterId(uint32_t can_id,
 #endif
 }
 
-HAL_StatusTypeDef CANDevice::AddFilterRange(uint32_t can_id,
+HAL_StatusTypeDef CANDevice::addFilterRange(uint32_t can_id,
                                             uint32_t range,
                                             sg::CANFrameIDType id_type,
                                             sg::CANFrameRTRMode rtr_mode,
@@ -624,7 +624,10 @@ HAL_StatusTypeDef CANDevice::RxCallback(CanHandle_t* hcan)
         // Queue the simple struct (safe to copy)
         osStatus_t stat = osMessageQueuePut(self->rx_queue_, &msg, 0, 0);
         if (stat != osOK)
+        {
+            self->dropped_rx_frame_count_.fetch_add(1, std::memory_order_relaxed);
             return HAL_BUSY;
+        }
     }
 
     // Now signal the task that messages are available
@@ -651,24 +654,23 @@ void CANDevice::HandleRxTrampoline(void* arg)
         if (osMessageQueueGet(rx_queue_, &msg, nullptr, osWaitForever) == osOK)
         {
             // Process the message
-            const CanCallback* cb = find_by_id(msg.can_id);
-            if (cb)
+            if (const CanCallback* cb = find_by_id(msg.can_id); cb)
             {
                 (*cb)(msg, this);
-                continue;
             }
-
-            cb = find_by_range(msg.can_id);
-            if (cb)
+            else if (cb = find_by_range(msg.can_id); cb)
             {
                 (*cb)(msg, this);
-                continue;
             }
-
-            if (allCallback_)
+            else if (allCallback_)
             {
                 allCallback_(msg, this);
             }
+            else
+            {
+                continue;
+            }
+            processed_messages_count_.fetch_add(1, std::memory_order_relaxed);
         }
     }
 }
@@ -687,8 +689,11 @@ void CANDevice::HandleTxTrampoline(void* arg)
 
         // Spinlock until a tx mailbox is empty
 #if defined(HAL_FDCAN_MODULE_ENABLED)
+        // TODO: use event/callback/sem so thread blocks when no slot in mailbox
         while (!HAL_FDCAN_GetTxFifoFreeLevel(hcan_))
-            ;
+        {
+            osDelay(1);
+        }
 
         FDCAN_TxHeaderTypeDef txHeader = {
             .Identifier = tx_msg.can_id,
@@ -705,6 +710,7 @@ void CANDevice::HandleTxTrampoline(void* arg)
 
         // Request HAL message send
         HAL_FDCAN_AddMessageToTxFifoQ(hcan_, &txHeader, tx_msg.data);
+        sent_messages_count_.fetch_add(1, std::memory_order_relaxed);
 #else
         while (!HAL_CAN_GetTxMailboxesFreeLevel(hcan_))
             ;
@@ -726,7 +732,7 @@ void CANDevice::HandleTxTrampoline(void* arg)
     }
 }
 
-HAL_StatusTypeDef CANDevice::Send(const CANFrame& msg)
+HAL_StatusTypeDef CANDevice::send(const CANFrame& msg)
 {
     if (osMessageQueuePut(tx_queue_, &msg, 0, TX_TIMEOUT) != osOK)
     {


### PR DESCRIPTION
some can driver refactoring as well as spliting rear vcu message into two since we can only send 8 byte messages

splits rear vcu message into two as shown on can map in teams
osDelay() when waiting on mailbox
naming refactors minor stuff
adds counters in can driver for messages recieved, messages sent, and dropped frames

Should be tested on hardware first