### PR TITLE
New bms message, can driver refactor, rearvcu sending change per can map, enums in shared drivers folder, rearvcu and steering state refactor

### DIFF
--- a/firmware/Rear-VCU/CMakeLists.txt
+++ b/firmware/Rear-VCU/CMakeLists.txt
@@ -44,7 +44,7 @@ set(PROJECT_INCLUDE_DIRECTORIES
     ${USER_DIR}/inc
     ${RESOURCES_DIR}/Drivers/SG_Drivers/CAN/Include
     ${RESOURCES_DIR}/Drivers/SG_Drivers/Inc
-    ${RESOURCES_DIR}/Drivers/SG_Drivers/Src/*.tpp)
+    ${RESOURCES_DIR}/Drivers/SG_Drivers/flare)
 # Sources
 file(GLOB STM32CUBEMX_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Src/*.c

--- a/firmware/Rear-VCU/user/inc/can.hpp
+++ b/firmware/Rear-VCU/user/inc/can.hpp
@@ -6,7 +6,7 @@ extern FDCAN_HandleTypeDef hfdcan1;
 inline sg::CANDevice can_device(
     &hfdcan1);  // inline on variable declared in header file like this allows
                 // us to avoid odr when including in multiple cpp files, all references to it
-                // will correctly refer to a single instance of the variable.
+                // will correctly refer to this single instance of the variable.
 
 constexpr sg::CANFrame mitsuba_frame0_request = {
     .can_id = 0x08F89540,

--- a/firmware/Rear-VCU/user/inc/can.hpp
+++ b/firmware/Rear-VCU/user/inc/can.hpp
@@ -3,6 +3,9 @@
 
 extern FDCAN_HandleTypeDef hfdcan1;
 
+namespace rearvcu
+{
+
 inline sg::CANDevice can_device(
     &hfdcan1);  // inline on variable declared in header file like this allows
                 // us to avoid odr when including in multiple cpp files, all references to it
@@ -21,3 +24,5 @@ HAL_StatusTypeDef driverMessageCallback(const sg::CANFrame& msg, void* ctx);
 HAL_StatusTypeDef mitsubaFrame0Callback(const sg::CANFrame& msg, void* ctx);
 
 void can_init();
+
+}  // namespace rearvcu

--- a/firmware/Rear-VCU/user/inc/rearvcu_state.h
+++ b/firmware/Rear-VCU/user/inc/rearvcu_state.h
@@ -34,9 +34,6 @@ struct VCUState
     std::atomic<bool> array_contactors_requested_closed{};
     std::atomic<Direction> direction_requested{};
     std::atomic<MCPowerMode> mc_power_mode_requested{};
-
-    std::atomic<uint32_t> can_messages_received{};
-    std::atomic<uint32_t> can_messages_sent{};
 };
 
 inline VCUState vcu_state;

--- a/firmware/Rear-VCU/user/inc/rearvcu_state.h
+++ b/firmware/Rear-VCU/user/inc/rearvcu_state.h
@@ -5,7 +5,7 @@
 
 #include <atomic>
 
-namespace vcu
+namespace rearvcu
 {
 
 struct RearVCUState

--- a/firmware/Rear-VCU/user/inc/rearvcu_state.h
+++ b/firmware/Rear-VCU/user/inc/rearvcu_state.h
@@ -24,4 +24,4 @@ struct RearVCUState
 
 inline RearVCUState state;
 
-}  // namespace vcu
+}  // namespace rearvcu

--- a/firmware/Rear-VCU/user/inc/rearvcu_state.h
+++ b/firmware/Rear-VCU/user/inc/rearvcu_state.h
@@ -1,28 +1,14 @@
 #pragma once
 #include <cstdint>
 
+#include "can_protocol.h"
+
 #include <atomic>
 
-enum class ArrayContactors : uint8_t
+namespace vcu
 {
-    BOTH_OPEN = 0,
-    PRECHARGE_CLOSED = 1,
-    MAIN_CLOSED = 2
-};
 
-enum class Direction : uint8_t
-{
-    REVERSE = 0,
-    FORWARD = 1
-};
-
-enum class MCPowerMode : uint8_t
-{
-    ECO = 0,
-    POWER = 1
-};
-
-struct VCUState
+struct RearVCUState
 {
     std::atomic<uint16_t> throttle_requested{};  // 0 - 65535 from front vcu
     std::atomic<uint8_t> regen_requested{};      // 0 - 255
@@ -32,8 +18,10 @@ struct VCUState
 
     std::atomic<bool> mc_enabled_requested;  // true if requested enabled
     std::atomic<bool> array_contactors_requested_closed{};
-    std::atomic<Direction> direction_requested{};
-    std::atomic<MCPowerMode> mc_power_mode_requested{};
+    std::atomic<flare_can::Direction> direction_requested{};
+    std::atomic<flare_can::MCPowerMode> mc_power_mode_requested{};
 };
 
-inline VCUState vcu_state;
+inline RearVCUState state;
+
+}  // namespace vcu

--- a/firmware/Rear-VCU/user/src/can.cpp
+++ b/firmware/Rear-VCU/user/src/can.cpp
@@ -36,8 +36,6 @@ HAL_StatusTypeDef throttleMessageCallback(const sg::CANFrame& msg, void* ctx)
         (static_cast<uint16_t>(throttle_high) << 8) | static_cast<uint16_t>(throttle_low);
     vcu_state.throttle_requested.store(throttle_value);
 
-    ++vcu_state.can_messages_received;
-
     return HAL_OK;
 }
 
@@ -47,8 +45,6 @@ HAL_StatusTypeDef driverMessageCallback(const sg::CANFrame& msg, void* ctx)
     vcu_state.array_contactors_requested_closed.store(static_cast<bool>(msg.data[2]));
     vcu_state.regen_requested.store(msg.data[5]);
     vcu_state.mc_power_mode_requested.store(static_cast<MCPowerMode>(msg.data[6]));
-
-    ++vcu_state.can_messages_received;
 
     return HAL_OK;
 }
@@ -77,8 +73,6 @@ HAL_StatusTypeDef mitsubaFrame0Callback(const sg::CANFrame& msg, void* ctx)
 
     vcu_state.car_speed.store(static_cast<uint8_t>(std::round(miles_per_hour)));
 
-    ++vcu_state.can_messages_received;
-
     return HAL_OK;
 }
 
@@ -97,5 +91,5 @@ void can_init()
         0x08850225, sg::CANFrameIDType::EXTENDED, &mitsubaFrame0Callback, nullptr));
 
     // start
-    ASSERT_HAL_OK(can_device.StartCANDevice());
+    ASSERT_HAL_OK(can_device.startCANDevice());
 }

--- a/firmware/Rear-VCU/user/src/can.cpp
+++ b/firmware/Rear-VCU/user/src/can.cpp
@@ -28,23 +28,26 @@
     if (!statement)            \
         Error_Handler();
 
+namespace rearvcu
+{
+
 HAL_StatusTypeDef throttleMessageCallback(const sg::CANFrame& msg, void* ctx)
 {
     uint8_t throttle_low = msg.data[0];
     uint8_t throttle_high = msg.data[1];
     uint16_t throttle_value =
         (static_cast<uint16_t>(throttle_high) << 8) | static_cast<uint16_t>(throttle_low);
-    rearvcu::state.throttle_requested.store(throttle_value);
+    state.throttle_requested.store(throttle_value);
 
     return HAL_OK;
 }
 
 HAL_StatusTypeDef driverMessageCallback(const sg::CANFrame& msg, void* ctx)
 {
-    rearvcu::state.direction_requested.store(static_cast<flare_can::Direction>(msg.data[1]));
-    rearvcu::state.array_contactors_requested_closed.store(static_cast<bool>(msg.data[2]));
-    rearvcu::state.regen_requested.store(msg.data[5]);
-    rearvcu::state.mc_power_mode_requested.store(static_cast<flare_can::MCPowerMode>(msg.data[6]));
+    state.direction_requested.store(static_cast<flare_can::Direction>(msg.data[1]));
+    state.array_contactors_requested_closed.store(static_cast<bool>(msg.data[2]));
+    state.regen_requested.store(msg.data[5]);
+    state.mc_power_mode_requested.store(static_cast<flare_can::MCPowerMode>(msg.data[6]));
 
     return HAL_OK;
 }
@@ -71,7 +74,7 @@ HAL_StatusTypeDef mitsubaFrame0Callback(const sg::CANFrame& msg, void* ctx)
     double miles_per_sec = inches_per_sec / 63360;   // 1 mile = 63360 inches
     double miles_per_hour = (miles_per_sec * 3600);  // 1 hour = 3600 seconds
 
-    rearvcu::state.car_speed.store(static_cast<uint8_t>(std::round(miles_per_hour)));
+    state.car_speed.store(static_cast<uint8_t>(std::round(miles_per_hour)));
 
     return HAL_OK;
 }
@@ -93,3 +96,5 @@ void can_init()
     // start
     ASSERT_HAL_OK(can_device.startCANDevice());
 }
+
+}  // namespace rearvcu

--- a/firmware/Rear-VCU/user/src/can.cpp
+++ b/firmware/Rear-VCU/user/src/can.cpp
@@ -34,17 +34,17 @@ HAL_StatusTypeDef throttleMessageCallback(const sg::CANFrame& msg, void* ctx)
     uint8_t throttle_high = msg.data[1];
     uint16_t throttle_value =
         (static_cast<uint16_t>(throttle_high) << 8) | static_cast<uint16_t>(throttle_low);
-    vcu_state.throttle_requested.store(throttle_value);
+    vcu::state.throttle_requested.store(throttle_value);
 
     return HAL_OK;
 }
 
 HAL_StatusTypeDef driverMessageCallback(const sg::CANFrame& msg, void* ctx)
 {
-    vcu_state.direction_requested.store(static_cast<Direction>(msg.data[1]));
-    vcu_state.array_contactors_requested_closed.store(static_cast<bool>(msg.data[2]));
-    vcu_state.regen_requested.store(msg.data[5]);
-    vcu_state.mc_power_mode_requested.store(static_cast<MCPowerMode>(msg.data[6]));
+    vcu::state.direction_requested.store(static_cast<flare_can::Direction>(msg.data[1]));
+    vcu::state.array_contactors_requested_closed.store(static_cast<bool>(msg.data[2]));
+    vcu::state.regen_requested.store(msg.data[5]);
+    vcu::state.mc_power_mode_requested.store(static_cast<flare_can::MCPowerMode>(msg.data[6]));
 
     return HAL_OK;
 }
@@ -71,7 +71,7 @@ HAL_StatusTypeDef mitsubaFrame0Callback(const sg::CANFrame& msg, void* ctx)
     double miles_per_sec = inches_per_sec / 63360;   // 1 mile = 63360 inches
     double miles_per_hour = (miles_per_sec * 3600);  // 1 hour = 3600 seconds
 
-    vcu_state.car_speed.store(static_cast<uint8_t>(std::round(miles_per_hour)));
+    vcu::state.car_speed.store(static_cast<uint8_t>(std::round(miles_per_hour)));
 
     return HAL_OK;
 }

--- a/firmware/Rear-VCU/user/src/can.cpp
+++ b/firmware/Rear-VCU/user/src/can.cpp
@@ -34,17 +34,17 @@ HAL_StatusTypeDef throttleMessageCallback(const sg::CANFrame& msg, void* ctx)
     uint8_t throttle_high = msg.data[1];
     uint16_t throttle_value =
         (static_cast<uint16_t>(throttle_high) << 8) | static_cast<uint16_t>(throttle_low);
-    vcu::state.throttle_requested.store(throttle_value);
+    rearvcu::state.throttle_requested.store(throttle_value);
 
     return HAL_OK;
 }
 
 HAL_StatusTypeDef driverMessageCallback(const sg::CANFrame& msg, void* ctx)
 {
-    vcu::state.direction_requested.store(static_cast<flare_can::Direction>(msg.data[1]));
-    vcu::state.array_contactors_requested_closed.store(static_cast<bool>(msg.data[2]));
-    vcu::state.regen_requested.store(msg.data[5]);
-    vcu::state.mc_power_mode_requested.store(static_cast<flare_can::MCPowerMode>(msg.data[6]));
+    rearvcu::state.direction_requested.store(static_cast<flare_can::Direction>(msg.data[1]));
+    rearvcu::state.array_contactors_requested_closed.store(static_cast<bool>(msg.data[2]));
+    rearvcu::state.regen_requested.store(msg.data[5]);
+    rearvcu::state.mc_power_mode_requested.store(static_cast<flare_can::MCPowerMode>(msg.data[6]));
 
     return HAL_OK;
 }
@@ -71,7 +71,7 @@ HAL_StatusTypeDef mitsubaFrame0Callback(const sg::CANFrame& msg, void* ctx)
     double miles_per_sec = inches_per_sec / 63360;   // 1 mile = 63360 inches
     double miles_per_hour = (miles_per_sec * 3600);  // 1 hour = 3600 seconds
 
-    vcu::state.car_speed.store(static_cast<uint8_t>(std::round(miles_per_hour)));
+    rearvcu::state.car_speed.store(static_cast<uint8_t>(std::round(miles_per_hour)));
 
     return HAL_OK;
 }

--- a/firmware/Rear-VCU/user/src/user_threads.cpp
+++ b/firmware/Rear-VCU/user/src/user_threads.cpp
@@ -42,7 +42,7 @@ void init_user()
     // TODO: initialize ina chip here
 
     // can
-    can_init();
+    rearvcu::can_init();
 }
 
 [[noreturn]] void startHeartbeatTask_user(void* argument)
@@ -60,7 +60,7 @@ void init_user()
         HAL_GPIO_TogglePin(OK_LED_GPIO_Port, OK_LED_Pin);
 
         // send mitsuba request for frame0 to get wheel rpm, shouldnt be sent faster than every 500ms
-        can_device.send(mitsuba_frame0_request);
+        rearvcu::can_device.send(rearvcu::mitsuba_frame0_request);
 
         // supp batt voltage can be read and sent in this thread as its not as urgent/important
         uint16_t supp_batt_voltage_mv = 0xFFFF;  // TODO: could get voltage of supp batt here
@@ -69,7 +69,7 @@ void init_user()
         supp_batt_frame.data[1] = static_cast<uint8_t>(supp_batt_voltage_mv >> 8);  // msb
         supp_batt_frame.data[2] = static_cast<uint8_t>(supp_batt_current);          // lsb
         supp_batt_frame.data[3] = static_cast<uint8_t>(supp_batt_current >> 8);     // msb
-        can_device.send(supp_batt_frame);
+        rearvcu::can_device.send(supp_batt_frame);
 
         osDelay(500);
     }
@@ -155,7 +155,7 @@ void init_user()
         rearvcu_statuses_frame.data[2] = static_cast<uint8_t>(mc_power_mode_requested);
         rearvcu_statuses_frame.data[3] = static_cast<uint8_t>(array_contactors);
         rearvcu_statuses_frame.data[4] = rearvcu::state.car_speed.load();
-        can_device.send(rearvcu_statuses_frame);
+        rearvcu::can_device.send(rearvcu_statuses_frame);
 
         osDelay(200);
     }

--- a/firmware/Rear-VCU/user/src/user_threads.cpp
+++ b/firmware/Rear-VCU/user/src/user_threads.cpp
@@ -109,7 +109,8 @@ void init_user()
     {
         // TODO: can make these writes less frequent using flag, only call writepin on change yk
         // power eco pin
-        flare_can::MCPowerMode mc_power_mode_requested = rearvcu::state.mc_power_mode_requested.load();
+        flare_can::MCPowerMode mc_power_mode_requested =
+            rearvcu::state.mc_power_mode_requested.load();
         HAL_GPIO_WritePin(MC_PWR_ECO_CTRL_GPIO_Port,
                           MC_PWR_ECO_CTRL_Pin,
                           static_cast<GPIO_PinState>(mc_power_mode_requested));

--- a/firmware/Rear-VCU/user/src/user_threads.cpp
+++ b/firmware/Rear-VCU/user/src/user_threads.cpp
@@ -102,20 +102,20 @@ void init_user()
                                         0,
                                         {}};
 
-    ArrayContactors array_contactors = ArrayContactors::BOTH_OPEN;
+    flare_can::ArrayContactors array_contactors = flare_can::ArrayContactors::BOTH_OPEN;
     uint32_t precharge_closed_timestamp = 0;
 
     for (;;)
     {
         // TODO: can make these writes less frequent using flag, only call writepin on change yk
         // power eco pin
-        MCPowerMode mc_power_mode_requested = vcu_state.mc_power_mode_requested.load();
+        flare_can::MCPowerMode mc_power_mode_requested = vcu::state.mc_power_mode_requested.load();
         HAL_GPIO_WritePin(MC_PWR_ECO_CTRL_GPIO_Port,
                           MC_PWR_ECO_CTRL_Pin,
                           static_cast<GPIO_PinState>(mc_power_mode_requested));
 
         // direction pin
-        Direction direction_requested = vcu_state.direction_requested.load();
+        flare_can::Direction direction_requested = vcu_state.direction_requested.load();
         HAL_GPIO_WritePin(MC_FWD_REV_CTRL_GPIO_Port,
                           MC_FWD_REV_CTRL_Pin,
                           static_cast<GPIO_PinState>(direction_requested));

--- a/firmware/Rear-VCU/user/src/user_threads.cpp
+++ b/firmware/Rear-VCU/user/src/user_threads.cpp
@@ -109,34 +109,34 @@ void init_user()
     {
         // TODO: can make these writes less frequent using flag, only call writepin on change yk
         // power eco pin
-        flare_can::MCPowerMode mc_power_mode_requested = vcu::state.mc_power_mode_requested.load();
+        flare_can::MCPowerMode mc_power_mode_requested = rearvcu::state.mc_power_mode_requested.load();
         HAL_GPIO_WritePin(MC_PWR_ECO_CTRL_GPIO_Port,
                           MC_PWR_ECO_CTRL_Pin,
                           static_cast<GPIO_PinState>(mc_power_mode_requested));
 
         // direction pin
-        flare_can::Direction direction_requested = vcu_state.direction_requested.load();
+        flare_can::Direction direction_requested = rearvcu::state.direction_requested.load();
         HAL_GPIO_WritePin(MC_FWD_REV_CTRL_GPIO_Port,
                           MC_FWD_REV_CTRL_Pin,
                           static_cast<GPIO_PinState>(direction_requested));
 
         // array contactors logic
         // TODO: user timer peripheral for consistent timer logic
-        if (vcu_state.array_contactors_requested_closed.load())
+        if (rearvcu::state.array_contactors_requested_closed.load())
         {
-            if (array_contactors == ArrayContactors::BOTH_OPEN)
+            if (array_contactors == flare_can::ArrayContactors::BOTH_OPEN)
             {
                 // close pre
                 HAL_GPIO_WritePin(PRE_ARRAY_CTRL_GPIO_Port, PRE_ARRAY_CTRL_Pin, GPIO_PIN_SET);
                 precharge_closed_timestamp = HAL_GetTick();
-                array_contactors = ArrayContactors::PRECHARGE_CLOSED;
+                array_contactors = flare_can::ArrayContactors::PRECHARGE_CLOSED;
             }
-            else if (array_contactors == ArrayContactors::PRECHARGE_CLOSED &&
+            else if (array_contactors == flare_can::ArrayContactors::PRECHARGE_CLOSED &&
                      HAL_GetTick() - precharge_closed_timestamp > ARRAY_PRECHARGE_HOLD_TIME_MS)
             {
                 // close main
                 HAL_GPIO_WritePin(MAIN_ARRAY_CTRL_GPIO_Port, MAIN_ARRAY_CTRL_Pin, GPIO_PIN_SET);
-                array_contactors = ArrayContactors::MAIN_CLOSED;
+                array_contactors = flare_can::ArrayContactors::MAIN_CLOSED;
             }
         }
         else
@@ -144,7 +144,7 @@ void init_user()
             // open both contactors
             HAL_GPIO_WritePin(PRE_ARRAY_CTRL_GPIO_Port, PRE_ARRAY_CTRL_Pin, GPIO_PIN_RESET);
             HAL_GPIO_WritePin(MAIN_ARRAY_CTRL_GPIO_Port, MAIN_ARRAY_CTRL_Pin, GPIO_PIN_RESET);
-            array_contactors = ArrayContactors::BOTH_OPEN;
+            array_contactors = flare_can::ArrayContactors::BOTH_OPEN;
         }
 
         // setup and send diagnostic can message
@@ -153,7 +153,7 @@ void init_user()
         rearvcu_statuses_frame.data[1] = static_cast<uint8_t>(direction_requested);
         rearvcu_statuses_frame.data[2] = static_cast<uint8_t>(mc_power_mode_requested);
         rearvcu_statuses_frame.data[3] = static_cast<uint8_t>(array_contactors);
-        rearvcu_statuses_frame.data[4] = vcu_state.car_speed.load();
+        rearvcu_statuses_frame.data[4] = rearvcu::state.car_speed.load();
         can_device.send(rearvcu_statuses_frame);
 
         osDelay(200);

--- a/firmware/Rear-VCU/user/src/user_threads.cpp
+++ b/firmware/Rear-VCU/user/src/user_threads.cpp
@@ -47,16 +47,31 @@ void init_user()
 
 [[noreturn]] void startHeartbeatTask_user(void* argument)
 {
+    sg::CANFrame supp_batt_frame{0x021,
+                                 sg::CANFrameIDType::STANDARD,
+                                 sg::CANFrameRTRMode::DATA,
+                                 sg::CANFrameLen::BYTES_4,
+                                 0,
+                                 {}};
+
     for (;;)
     {
         // blink ok led
         HAL_GPIO_TogglePin(OK_LED_GPIO_Port, OK_LED_Pin);
 
         // send mitsuba request for frame0 to get wheel rpm, shouldnt be sent faster than every 500ms
-        can_device.Send(mitsuba_frame0_request);
-        ++vcu_state.can_messages_sent;
+        can_device.send(mitsuba_frame0_request);
 
-        osDelay(550);
+        // supp batt voltage can be read and sent in this thread as its not as urgent/important
+        uint16_t supp_batt_voltage_mv = 0xFFFF;  // TODO: could get voltage of supp batt here
+        uint16_t supp_batt_current = 0xFFFF;     // TODO: could get current draw of supp batt here
+        supp_batt_frame.data[0] = static_cast<uint8_t>(supp_batt_voltage_mv);       // lsb
+        supp_batt_frame.data[1] = static_cast<uint8_t>(supp_batt_voltage_mv >> 8);  // msb
+        supp_batt_frame.data[2] = static_cast<uint8_t>(supp_batt_current);          // lsb
+        supp_batt_frame.data[3] = static_cast<uint8_t>(supp_batt_current >> 8);     // msb
+        can_device.send(supp_batt_frame);
+
+        osDelay(500);
     }
 }
 
@@ -83,7 +98,7 @@ void init_user()
     sg::CANFrame rearvcu_statuses_frame{0x020,
                                         sg::CANFrameIDType::STANDARD,
                                         sg::CANFrameRTRMode::DATA,
-                                        sg::CANFrameLen::BYTES_16,
+                                        sg::CANFrameLen::BYTES_8,
                                         0,
                                         {}};
 
@@ -132,24 +147,14 @@ void init_user()
             array_contactors = ArrayContactors::BOTH_OPEN;
         }
 
-        // TODO: could get voltage of supp batt here
-        uint16_t supp_batt_voltage_mv = 0x0F0F;  // dummy
-
-        // TODO: could get current draw of supp batt here
-        uint16_t supp_batt_current = 0x0F0F;  // dummy
-
         // setup and send diagnostic can message
         rearvcu_statuses_frame.data[0] =
             1;  // mc enable should always be enabled if this board is alive, written to at startup
         rearvcu_statuses_frame.data[1] = static_cast<uint8_t>(direction_requested);
         rearvcu_statuses_frame.data[2] = static_cast<uint8_t>(mc_power_mode_requested);
         rearvcu_statuses_frame.data[3] = static_cast<uint8_t>(array_contactors);
-        rearvcu_statuses_frame.data[4] = static_cast<uint8_t>(supp_batt_voltage_mv);       // lsb
-        rearvcu_statuses_frame.data[5] = static_cast<uint8_t>(supp_batt_voltage_mv >> 8);  // msb
-        rearvcu_statuses_frame.data[6] = static_cast<uint8_t>(supp_batt_current);          // lsb
-        rearvcu_statuses_frame.data[7] = static_cast<uint8_t>(supp_batt_current >> 8);     // msb
-        rearvcu_statuses_frame.data[8] = vcu_state.car_speed.load();
-        can_device.Send(rearvcu_statuses_frame);
+        rearvcu_statuses_frame.data[4] = vcu_state.car_speed.load();
+        can_device.send(rearvcu_statuses_frame);
 
         osDelay(200);
     }

--- a/firmware/Steering-Wheel/CMakeLists.txt
+++ b/firmware/Steering-Wheel/CMakeLists.txt
@@ -44,7 +44,7 @@ set(PROJECT_INCLUDE_DIRECTORIES
     ${USER_DIR}/inc
     ${RESOURCES_DIR}/Drivers/SG_Drivers/CAN/Include
     ${RESOURCES_DIR}/Drivers/SG_Drivers/Inc
-    ${RESOURCES_DIR}/Drivers/SG_Drivers/Src/*.tpp)
+    ${RESOURCES_DIR}/Drivers/SG_Drivers/flare)
 # Sources
 file(GLOB STM32CUBEMX_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/Core/Src/*.c

--- a/firmware/Steering-Wheel/user/inc/buttons.h
+++ b/firmware/Steering-Wheel/user/inc/buttons.h
@@ -12,6 +12,9 @@
 
 // paddles do cc or regen strengths depending on mode maybe
 
+namespace steering
+{
+
 void button1PressedCallback();
 void button2PressedCallback();
 void button3PressedCallback();
@@ -24,3 +27,5 @@ void button8PressedCallback();
 void initButtons();
 
 void recalculateTurnSignals();
+
+}  // namespace steering

--- a/firmware/Steering-Wheel/user/inc/can.h
+++ b/firmware/Steering-Wheel/user/inc/can.h
@@ -3,6 +3,9 @@
 
 extern FDCAN_HandleTypeDef hfdcan1;
 
+namespace steering
+{
+
 inline sg::CANDevice can_device(&hfdcan1);
 
 void can_init();
@@ -10,3 +13,5 @@ void can_init();
 HAL_StatusTypeDef rearVCUInfoMessageCallback(const sg::CANFrame& msg, void* ctx);
 HAL_StatusTypeDef bmsBatteryVoltageMessageCallback(const sg::CANFrame& msg, void* ctx);
 HAL_StatusTypeDef bmsBatteryTempMessageCallback(const sg::CANFrame& msg, void* ctx);
+
+}  // namespace steering

--- a/firmware/Steering-Wheel/user/inc/can.h
+++ b/firmware/Steering-Wheel/user/inc/can.h
@@ -8,3 +8,5 @@ inline sg::CANDevice can_device(&hfdcan1);
 void can_init();
 
 HAL_StatusTypeDef rearVCUInfoMessageCallback(const sg::CANFrame& msg, void* ctx);
+HAL_StatusTypeDef bmsBatteryVoltageMessageCallback(const sg::CANFrame& msg, void* ctx);
+HAL_StatusTypeDef bmsBatteryTempMessageCallback(const sg::CANFrame& msg, void* ctx);

--- a/firmware/Steering-Wheel/user/inc/steering_state.h
+++ b/firmware/Steering-Wheel/user/inc/steering_state.h
@@ -47,9 +47,6 @@ struct SteeringState
     std::atomic<uint8_t> car_speed{};
     std::atomic<ArrayContactors> array_contactors_status{};
     std::atomic<uint16_t> supp_batt_voltage{};
-
-    std::atomic<uint32_t> can_messages_received{};
-    std::atomic<uint32_t> can_messages_sent{};
 };
 
 inline SteeringState steering_state;

--- a/firmware/Steering-Wheel/user/inc/steering_state.h
+++ b/firmware/Steering-Wheel/user/inc/steering_state.h
@@ -2,34 +2,12 @@
 
 #include <cstdint>
 
+#include "can_protocol.h"
+
 #include <atomic>
 
-enum class ArrayContactors : uint8_t
+namespace steering
 {
-    BOTH_OPEN = 0,
-    PRECHARGE_CLOSED = 1,
-    MAIN_CLOSED = 2
-};
-
-enum class TurnSignals : uint8_t
-{
-    OFF = 0,
-    LEFT = 1,
-    RIGHT = 1,
-    HAZARDS = 2
-};
-
-enum class Direction : uint8_t
-{
-    REVERSE = 0,
-    FORWARD = 1
-};
-
-enum class MCPowerMode : uint8_t
-{
-    ECO = 0,
-    POWER = 1
-};
 
 struct SteeringState
 {
@@ -39,14 +17,18 @@ struct SteeringState
     std::atomic<bool> array_contactors_requested_closed{};
     std::atomic<bool> horn_requested_on{};
     std::atomic<bool> headlights_requested_on{};
-    std::atomic<Direction> direction_requested{};
-    std::atomic<MCPowerMode> mc_power_mode_requested{};
-    std::atomic<TurnSignals> turn_signals_requested{};
+    std::atomic<flare_can::Direction> direction_requested{};
+    std::atomic<flare_can::MCPowerMode> mc_power_mode_requested{};
+    std::atomic<flare_can::TurnSignals> turn_signals_requested{};
 
     // recieving
     std::atomic<uint8_t> car_speed{};
-    std::atomic<ArrayContactors> array_contactors_status{};
+    std::atomic<flare_can::ArrayContactors> array_contactors_status{};
     std::atomic<uint16_t> supp_batt_voltage{};
+    std::atomic<uint32_t> main_batt_voltage_mv{};
+    std::atomic<uint16_t> high_temp_dc{};  // C * 10
 };
 
-inline SteeringState steering_state;
+inline SteeringState state;
+
+}  // namespace steering

--- a/firmware/Steering-Wheel/user/inc/steering_state.h
+++ b/firmware/Steering-Wheel/user/inc/steering_state.h
@@ -24,8 +24,8 @@ struct SteeringState
     // recieving
     std::atomic<uint8_t> car_speed{};
     std::atomic<flare_can::ArrayContactors> array_contactors_status{};
-    std::atomic<uint16_t> supp_batt_voltage{};
-    std::atomic<uint32_t> main_batt_voltage_mv{};
+    std::atomic<uint16_t> supp_batt_voltage_mv{};
+    std::atomic<uint16_t> main_batt_voltage_cv{}; // V * 100
     std::atomic<uint16_t> high_temp_dc{};  // C * 10
 };
 

--- a/firmware/Steering-Wheel/user/inc/steering_state.h
+++ b/firmware/Steering-Wheel/user/inc/steering_state.h
@@ -25,8 +25,8 @@ struct SteeringState
     std::atomic<uint8_t> car_speed{};
     std::atomic<flare_can::ArrayContactors> array_contactors_status{};
     std::atomic<uint16_t> supp_batt_voltage_mv{};
-    std::atomic<uint16_t> main_batt_voltage_cv{}; // V * 100
-    std::atomic<uint16_t> high_temp_dc{};  // C * 10
+    std::atomic<uint16_t> main_batt_voltage_cv{};  // V * 100
+    std::atomic<uint16_t> high_temp_dc{};          // C * 10
 };
 
 inline SteeringState state;

--- a/firmware/Steering-Wheel/user/src/buttons.cpp
+++ b/firmware/Steering-Wheel/user/src/buttons.cpp
@@ -9,6 +9,9 @@
 
 #include <array>
 
+namespace steering
+{
+
 static std::array<sg::Button, 8> buttons = {{
     {BUTTON1_GPIO_Port, BUTTON1_Pin},
     {BUTTON2_GPIO_Port, BUTTON2_Pin},
@@ -162,3 +165,5 @@ void recalculateTurnSignals()
     else
         steering::state.turn_signals_requested.store(flare_can::TurnSignals::OFF);
 }
+
+}  // namespace steering

--- a/firmware/Steering-Wheel/user/src/buttons.cpp
+++ b/firmware/Steering-Wheel/user/src/buttons.cpp
@@ -53,12 +53,12 @@ void button2PressedCallback()
     if (buttons[1].GetToggleState())
     {
         HAL_GPIO_WritePin(BUTTON2_LED_GPIO_Port, BUTTON2_LED_Pin, GPIO_PIN_SET);
-        steering_state.headlights_requested_on.store(true);
+        steering::state.headlights_requested_on.store(true);
     }
     else
     {
         HAL_GPIO_WritePin(BUTTON2_LED_GPIO_Port, BUTTON2_LED_Pin, GPIO_PIN_RESET);
-        steering_state.headlights_requested_on.store(false);
+        steering::state.headlights_requested_on.store(false);
     }
 }
 
@@ -68,12 +68,12 @@ void button3PressedCallback()
     if (buttons[2].GetToggleState())
     {
         HAL_GPIO_WritePin(BUTTON3_LED_GPIO_Port, BUTTON3_LED_Pin, GPIO_PIN_SET);
-        steering_state.array_contactors_requested_closed.store(true);
+        steering::state.array_contactors_requested_closed.store(true);
     }
     else
     {
         HAL_GPIO_WritePin(BUTTON3_LED_GPIO_Port, BUTTON3_LED_Pin, GPIO_PIN_RESET);
-        steering_state.array_contactors_requested_closed.store(false);
+        steering::state.array_contactors_requested_closed.store(false);
     }
 }
 
@@ -83,12 +83,12 @@ void button6PressedCallback()
     if (buttons[5].GetToggleState())
     {
         HAL_GPIO_WritePin(BUTTON6_LED_GPIO_Port, BUTTON6_LED_Pin, GPIO_PIN_SET);
-        steering_state.direction_requested.store(Direction::FORWARD);
+        steering::state.direction_requested.store(flare_can::Direction::FORWARD);
     }
     else
     {
         HAL_GPIO_WritePin(BUTTON6_LED_GPIO_Port, BUTTON6_LED_Pin, GPIO_PIN_RESET);
-        steering_state.direction_requested.store(Direction::REVERSE);
+        steering::state.direction_requested.store(flare_can::Direction::REVERSE);
     }
 }
 
@@ -127,12 +127,12 @@ void button8PressedCallback()
     if (buttons[7].GetToggleState())
     {
         HAL_GPIO_WritePin(BUTTON8_LED_GPIO_Port, BUTTON8_LED_Pin, GPIO_PIN_SET);
-        steering_state.mc_power_mode_requested.store(MCPowerMode::POWER);
+        steering::state.mc_power_mode_requested.store(flare_can::MCPowerMode::POWER);
     }
     else
     {
         HAL_GPIO_WritePin(BUTTON8_LED_GPIO_Port, BUTTON8_LED_Pin, GPIO_PIN_RESET);
-        steering_state.mc_power_mode_requested.store(MCPowerMode::ECO);
+        steering::state.mc_power_mode_requested.store(flare_can::MCPowerMode::ECO);
     }
 }
 
@@ -154,11 +154,11 @@ void recalculateTurnSignals()
     bool right = buttons[4].GetToggleState();
 
     if (left && right)
-        steering_state.turn_signals_requested.store(TurnSignals::HAZARDS);
+        steering::state.turn_signals_requested.store(flare_can::TurnSignals::HAZARDS);
     else if (left)
-        steering_state.turn_signals_requested.store(TurnSignals::LEFT);
+        steering::state.turn_signals_requested.store(flare_can::TurnSignals::LEFT);
     else if (right)
-        steering_state.turn_signals_requested.store(TurnSignals::RIGHT);
+        steering::state.turn_signals_requested.store(flare_can::TurnSignals::RIGHT);
     else
-        steering_state.turn_signals_requested.store(TurnSignals::OFF);
+        steering::state.turn_signals_requested.store(flare_can::TurnSignals::OFF);
 }

--- a/firmware/Steering-Wheel/user/src/can.cpp
+++ b/firmware/Steering-Wheel/user/src/can.cpp
@@ -30,7 +30,7 @@ HAL_StatusTypeDef rearVCUInfoMessageCallback(const sg::CANFrame& msg, void* ctx)
         static_cast<flare_can::ArrayContactors>(msg.data[3]));
 
     uint16_t supp_batt_voltage = (msg.data[4]) | (static_cast<uint16_t>(msg.data[5]) << 8);
-    steering::state.supp_batt_voltage.store(supp_batt_voltage);
+    steering::state.supp_batt_voltage_mv.store(supp_batt_voltage);
 
     steering::state.car_speed.store(msg.data[8]);
 
@@ -39,10 +39,17 @@ HAL_StatusTypeDef rearVCUInfoMessageCallback(const sg::CANFrame& msg, void* ctx)
 
 HAL_StatusTypeDef bmsBatteryVoltageMessageCallback(const sg::CANFrame& msg, void* ctx)
 {
+    uint16_t main_batt_voltage_mv = static_cast<uint16_t>(msg.data[0] << 8) | (msg.data[1]);
+    steering::state.main_batt_voltage_cv.store(main_batt_voltage_mv);
+
     return HAL_OK;
 }
 
 HAL_StatusTypeDef bmsBatteryTempMessageCallback(const sg::CANFrame& msg, void* ctx)
 {
+    // dc here is like decicelcius
+    uint16_t highest_temp_cell_dc = static_cast<uint16_t>(msg.data[0] << 8) | (msg.data[1]);
+    steering::state.high_temp_dc.store(highest_temp_cell_dc);
+
     return HAL_OK;
 }

--- a/firmware/Steering-Wheel/user/src/can.cpp
+++ b/firmware/Steering-Wheel/user/src/can.cpp
@@ -12,6 +12,9 @@
     if (!statement)            \
         Error_Handler();
 
+namespace steering
+{
+
 void can_init()
 {
     // recieve message from rear vcu
@@ -53,3 +56,5 @@ HAL_StatusTypeDef bmsBatteryTempMessageCallback(const sg::CANFrame& msg, void* c
 
     return HAL_OK;
 }
+
+}  // namespace steering

--- a/firmware/Steering-Wheel/user/src/can.cpp
+++ b/firmware/Steering-Wheel/user/src/can.cpp
@@ -17,7 +17,7 @@ void can_init()
     // recieve message from rear vcu
     ASSERT_TRUE(can_device.addCallbackId(
         0x020, sg::CANFrameIDType::STANDARD, &rearVCUInfoMessageCallback, nullptr));
-    ASSERT_HAL_OK(can_device.StartCANDevice());
+    ASSERT_HAL_OK(can_device.startCANDevice());
 }
 
 HAL_StatusTypeDef rearVCUInfoMessageCallback(const sg::CANFrame& msg, void* ctx)
@@ -28,8 +28,6 @@ HAL_StatusTypeDef rearVCUInfoMessageCallback(const sg::CANFrame& msg, void* ctx)
     steering_state.supp_batt_voltage.store(supp_batt_voltage);
 
     steering_state.car_speed.store(msg.data[8]);
-
-    ++steering_state.can_messages_received;
 
     return HAL_OK;
 }

--- a/firmware/Steering-Wheel/user/src/can.cpp
+++ b/firmware/Steering-Wheel/user/src/can.cpp
@@ -17,17 +17,32 @@ void can_init()
     // recieve message from rear vcu
     ASSERT_TRUE(can_device.addCallbackId(
         0x020, sg::CANFrameIDType::STANDARD, &rearVCUInfoMessageCallback, nullptr));
+    ASSERT_TRUE(can_device.addCallbackId(
+        0x041, sg::CANFrameIDType::STANDARD, &bmsBatteryVoltageMessageCallback, nullptr));
+    ASSERT_TRUE(can_device.addCallbackId(
+        0x042, sg::CANFrameIDType::STANDARD, &bmsBatteryTempMessageCallback, nullptr));
     ASSERT_HAL_OK(can_device.startCANDevice());
 }
 
 HAL_StatusTypeDef rearVCUInfoMessageCallback(const sg::CANFrame& msg, void* ctx)
 {
-    steering_state.array_contactors_status.store(static_cast<ArrayContactors>(msg.data[3]));
+    steering::state.array_contactors_status.store(
+        static_cast<flare_can::ArrayContactors>(msg.data[3]));
 
     uint16_t supp_batt_voltage = (msg.data[4]) | (static_cast<uint16_t>(msg.data[5]) << 8);
-    steering_state.supp_batt_voltage.store(supp_batt_voltage);
+    steering::state.supp_batt_voltage.store(supp_batt_voltage);
 
-    steering_state.car_speed.store(msg.data[8]);
+    steering::state.car_speed.store(msg.data[8]);
 
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef bmsBatteryVoltageMessageCallback(const sg::CANFrame& msg, void* ctx)
+{
+    return HAL_OK;
+}
+
+HAL_StatusTypeDef bmsBatteryTempMessageCallback(const sg::CANFrame& msg, void* ctx)
+{
     return HAL_OK;
 }

--- a/firmware/Steering-Wheel/user/src/user_threads.cpp
+++ b/firmware/Steering-Wheel/user/src/user_threads.cpp
@@ -10,6 +10,9 @@
 #include "main.h"
 #include "steering_state.h"
 
+#include <array>
+#include <string>
+
 void init_user()
 {
     // check atomics
@@ -37,7 +40,23 @@ void startScreenTask_user(void* argument)
 
     for (;;)
     {
-        display.FillRect(50, 50, 50, 50, RGB565_RED);
+        display.ClearScreen(RGB565_WHITE);
+
+        uint32_t cv = steering::state.main_batt_voltage_cv.load(std::memory_order_relaxed);
+        uint32_t whole = cv / 100;
+        uint32_t frac  = (cv % 100);
+        std::array<char, 16> main_batt_v{};
+        snprintf(main_batt_v.data(), sizeof(main_batt_v), "%lu.%02lu",
+                 static_cast<unsigned long>(whole), static_cast<unsigned long>(frac));
+        display.DrawText(30, 30, main_batt_v.data(), RGB565_BLACK);
+
+        uint32_t dc = steering::state.high_temp_dc.load(std::memory_order_relaxed);
+        whole = dc / 10;
+        frac  = (dc % 10);
+        std::array<char, 16> high_temp_c{};
+        snprintf(high_temp_c.data(), sizeof(high_temp_c), "%lu.%lu",
+                 static_cast<unsigned long>(whole), static_cast<unsigned long>(frac));
+        display.DrawText(30, 60, high_temp_c.data(), RGB565_BLACK);
 
         osDelay(500);
     }

--- a/firmware/Steering-Wheel/user/src/user_threads.cpp
+++ b/firmware/Steering-Wheel/user/src/user_threads.cpp
@@ -12,6 +12,12 @@
 
 void init_user()
 {
+    // check atomics
+    static_assert(std::atomic<uint32_t>::is_always_lock_free);
+    static_assert(std::atomic<uint16_t>::is_always_lock_free);
+    static_assert(std::atomic<uint8_t>::is_always_lock_free);
+
+    // start can
     can_init();
 }
 
@@ -52,15 +58,15 @@ void startPollButtons_user(void* argument)
     {
         // turn signals
         steering_requests_frame.data[0] =
-            static_cast<uint8_t>(steering_state.turn_signals_requested.load());
+            static_cast<uint8_t>(steering::state.turn_signals_requested.load());
 
         // frwrd / reverse
         steering_requests_frame.data[1] =
-            static_cast<uint8_t>(steering_state.direction_requested.load());
+            static_cast<uint8_t>(steering::state.direction_requested.load());
 
         // array
         steering_requests_frame.data[2] =
-            static_cast<uint8_t>(steering_state.array_contactors_requested_closed.load());
+            static_cast<uint8_t>(steering::state.array_contactors_requested_closed.load());
 
         // horn
         steering_requests_frame.data[3] =
@@ -68,14 +74,14 @@ void startPollButtons_user(void* argument)
 
         // headlights
         steering_requests_frame.data[4] =
-            static_cast<uint8_t>(steering_state.headlights_requested_on.load());
+            static_cast<uint8_t>(steering::state.headlights_requested_on.load());
 
         // regen breaking strength
         steering_requests_frame.data[5] = 0;
 
         // pwr/eco request
         steering_requests_frame.data[6] =
-            static_cast<uint8_t>(steering_state.mc_power_mode_requested.load());
+            static_cast<uint8_t>(steering::state.mc_power_mode_requested.load());
 
         // cc mph
         steering_requests_frame.data[7] = 0;

--- a/firmware/Steering-Wheel/user/src/user_threads.cpp
+++ b/firmware/Steering-Wheel/user/src/user_threads.cpp
@@ -39,44 +39,48 @@ void startScreenTask_user(void* argument)
 
 void startPollButtons_user(void* argument)
 {
-    sg::CANFrame frame{0x064,
-                       sg::CANFrameIDType::STANDARD,
-                       sg::CANFrameRTRMode::DATA,
-                       sg::CANFrameLen::BYTES_8,
-                       0,
-                       {}};
+    sg::CANFrame steering_requests_frame{0x064,
+                                         sg::CANFrameIDType::STANDARD,
+                                         sg::CANFrameRTRMode::DATA,
+                                         sg::CANFrameLen::BYTES_8,
+                                         0,
+                                         {}};
 
     initButtons();
 
     for (;;)
     {
         // turn signals
-        frame.data[0] = static_cast<uint8_t>(steering_state.turn_signals_requested.load());
+        steering_requests_frame.data[0] =
+            static_cast<uint8_t>(steering_state.turn_signals_requested.load());
 
         // frwrd / reverse
-        frame.data[1] = static_cast<uint8_t>(steering_state.direction_requested.load());
+        steering_requests_frame.data[1] =
+            static_cast<uint8_t>(steering_state.direction_requested.load());
 
         // array
-        frame.data[2] =
+        steering_requests_frame.data[2] =
             static_cast<uint8_t>(steering_state.array_contactors_requested_closed.load());
 
         // horn
-        frame.data[3] = static_cast<uint8_t>(!HAL_GPIO_ReadPin(HORN_PORT, HORN_PIN));
+        steering_requests_frame.data[3] =
+            static_cast<uint8_t>(!HAL_GPIO_ReadPin(HORN_PORT, HORN_PIN));
 
         // headlights
-        frame.data[4] = static_cast<uint8_t>(steering_state.headlights_requested_on.load());
+        steering_requests_frame.data[4] =
+            static_cast<uint8_t>(steering_state.headlights_requested_on.load());
 
         // regen breaking strength
-        frame.data[5] = 0;
+        steering_requests_frame.data[5] = 0;
 
         // pwr/eco request
-        frame.data[6] = static_cast<uint8_t>(steering_state.mc_power_mode_requested.load());
+        steering_requests_frame.data[6] =
+            static_cast<uint8_t>(steering_state.mc_power_mode_requested.load());
 
         // cc mph
-        frame.data[7] = 0;
+        steering_requests_frame.data[7] = 0;
 
-        if (can_device.Send(frame) == HAL_OK)
-            ++steering_state.can_messages_sent;
+        can_device.send(steering_requests_frame);
 
         osDelay(20);
     }

--- a/firmware/Steering-Wheel/user/src/user_threads.cpp
+++ b/firmware/Steering-Wheel/user/src/user_threads.cpp
@@ -21,7 +21,7 @@ void init_user()
     static_assert(std::atomic<uint8_t>::is_always_lock_free);
 
     // start can
-    can_init();
+    steering::can_init();
 }
 
 void startHeartbeatTask_user(void* argument)
@@ -77,7 +77,7 @@ void startPollButtons_user(void* argument)
                                          0,
                                          {}};
 
-    initButtons();
+    steering::initButtons();
 
     for (;;)
     {
@@ -111,7 +111,7 @@ void startPollButtons_user(void* argument)
         // cc mph
         steering_requests_frame.data[7] = 0;
 
-        can_device.send(steering_requests_frame);
+        steering::can_device.send(steering_requests_frame);
 
         osDelay(20);
     }

--- a/firmware/Steering-Wheel/user/src/user_threads.cpp
+++ b/firmware/Steering-Wheel/user/src/user_threads.cpp
@@ -44,18 +44,24 @@ void startScreenTask_user(void* argument)
 
         uint32_t cv = steering::state.main_batt_voltage_cv.load(std::memory_order_relaxed);
         uint32_t whole = cv / 100;
-        uint32_t frac  = (cv % 100);
+        uint32_t frac = (cv % 100);
         std::array<char, 16> main_batt_v{};
-        snprintf(main_batt_v.data(), sizeof(main_batt_v), "%lu.%02lu",
-                 static_cast<unsigned long>(whole), static_cast<unsigned long>(frac));
+        snprintf(main_batt_v.data(),
+                 sizeof(main_batt_v),
+                 "%lu.%02lu",
+                 static_cast<unsigned long>(whole),
+                 static_cast<unsigned long>(frac));
         display.DrawText(30, 30, main_batt_v.data(), RGB565_BLACK);
 
         uint32_t dc = steering::state.high_temp_dc.load(std::memory_order_relaxed);
         whole = dc / 10;
-        frac  = (dc % 10);
+        frac = (dc % 10);
         std::array<char, 16> high_temp_c{};
-        snprintf(high_temp_c.data(), sizeof(high_temp_c), "%lu.%lu",
-                 static_cast<unsigned long>(whole), static_cast<unsigned long>(frac));
+        snprintf(high_temp_c.data(),
+                 sizeof(high_temp_c),
+                 "%lu.%lu",
+                 static_cast<unsigned long>(whole),
+                 static_cast<unsigned long>(frac));
         display.DrawText(30, 60, high_temp_c.data(), RGB565_BLACK);
 
         osDelay(500);

--- a/firmware/Telemetry/user/src/can.cpp
+++ b/firmware/Telemetry/user/src/can.cpp
@@ -16,7 +16,7 @@ void can_init()
         can_device.addCallbackId(0x064, sg::CANFrameIDType::STANDARD, &steeringRequestsCallback));
     ASSERT_TRUE(
         can_device.addCallbackId(0x020, sg::CANFrameIDType::STANDARD, &rearVCUStatusCallback));
-    ASSERT_HAL_OK(can_device.StartCANDevice());
+    ASSERT_HAL_OK(can_device.startCANDevice());
 }
 
 HAL_StatusTypeDef steeringRequestsCallback(const sg::CANFrame& frame, void* ctx)

--- a/resources/Drivers/SG_Drivers/CAN/Include/CanDriver.hpp
+++ b/resources/Drivers/SG_Drivers/CAN/Include/CanDriver.hpp
@@ -12,6 +12,7 @@
 #include "CanDriverApi.hpp"
 #include "FreeRTOS.h"
 
+#include <atomic>
 #include <vector>
 
 namespace sg
@@ -103,7 +104,7 @@ class CANDevice
      *
      * @return HAL_OK on success, or an appropriate HAL error/status code if startup fails.
      */
-    HAL_StatusTypeDef StartCANDevice();
+    HAL_StatusTypeDef startCANDevice();
 
     /*!
      * @brief Adds a hardware filter to accept a single CAN identifier.
@@ -121,7 +122,7 @@ class CANDevice
      *
      * @return HAL_OK if the filter was successfully added, or an error/status code if not.
      */
-    HAL_StatusTypeDef AddFilterId(uint32_t can_id,
+    HAL_StatusTypeDef addFilterId(uint32_t can_id,
                                   CANFrameIDType id_type,
                                   CANFrameRTRMode rtr_mode,
                                   CANFramePriority priority);
@@ -145,7 +146,7 @@ class CANDevice
      *
      * @return HAL_OK if the filter was successfully added, or an error/status code if not.
      */
-    HAL_StatusTypeDef AddFilterRange(uint32_t can_id,
+    HAL_StatusTypeDef addFilterRange(uint32_t can_id,
                                      uint32_t range,
                                      sg::CANFrameIDType id_type,
                                      sg::CANFrameRTRMode rtr_mode,
@@ -206,7 +207,22 @@ class CANDevice
      * @param msg message to be sent, CANDevice stores a copy of it in a buffer
      * @return HAL error code, HAL_OK if pushed to queue successfully
      */
-    HAL_StatusTypeDef Send(const CANFrame& msg);
+    HAL_StatusTypeDef send(const CANFrame& msg);
+
+    // returns the total number of messages that have been recieved and processed (ie a callback was called on it) by the device
+    uint32_t getProcessedMessagesCount()
+    {
+        return processed_messages_count_.load(std::memory_order_relaxed);
+    }
+
+    // returns the total number of messages that have been sent by the device (ie added to a tx mailbox)
+    uint32_t getSentMessagesCount() { return sent_messages_count_.load(std::memory_order_relaxed); }
+
+    // returns total number of frames that were dropped by the device because when trying to push frame when recieved in isr the queue was full
+    uint32_t getDroppedFrameCount()
+    {
+        return dropped_rx_frame_count_.load(std::memory_order_relaxed);
+    }
 
     // should be unused by user
     static HAL_StatusTypeDef RxCallback(CanHandle_t* hcan);
@@ -229,6 +245,11 @@ class CANDevice
 
     osMessageQueueId_t tx_queue_;
     osMessageQueueId_t rx_queue_;
+
+    std::atomic<uint32_t>
+        processed_messages_count_{};               // number of messages a callback was called on
+    std::atomic<uint32_t> sent_messages_count_{};  // count of messages added to mailbox to be sent
+    std::atomic<uint32_t> dropped_rx_frame_count_{};  // count of dropped rx frames
 
     struct Entry
     {

--- a/resources/Drivers/SG_Drivers/CAN/Src/CanDriver.cpp
+++ b/resources/Drivers/SG_Drivers/CAN/Src/CanDriver.cpp
@@ -175,7 +175,7 @@ CANDevice::CANDevice(CanHandle_t* hcan)
     rangeCallbacks_.reserve(NUM_CAN_CALLBACKS);
 }
 
-HAL_StatusTypeDef CANDevice::StartCANDevice()
+HAL_StatusTypeDef CANDevice::startCANDevice()
 {
     if (!registerHandle(hcan_, this))
     {
@@ -286,7 +286,7 @@ HAL_StatusTypeDef CANDevice::StartCANDevice()
     return HAL_OK;
 }
 
-HAL_StatusTypeDef CANDevice::AddFilterId(uint32_t can_id,
+HAL_StatusTypeDef CANDevice::addFilterId(uint32_t can_id,
                                          CANFrameIDType id_type,
                                          CANFrameRTRMode rtr_mode,
                                          CANFramePriority priority)
@@ -396,7 +396,7 @@ HAL_StatusTypeDef CANDevice::AddFilterId(uint32_t can_id,
 #endif
 }
 
-HAL_StatusTypeDef CANDevice::AddFilterRange(uint32_t can_id,
+HAL_StatusTypeDef CANDevice::addFilterRange(uint32_t can_id,
                                             uint32_t range,
                                             sg::CANFrameIDType id_type,
                                             sg::CANFrameRTRMode rtr_mode,
@@ -624,7 +624,10 @@ HAL_StatusTypeDef CANDevice::RxCallback(CanHandle_t* hcan)
         // Queue the simple struct (safe to copy)
         osStatus_t stat = osMessageQueuePut(self->rx_queue_, &msg, 0, 0);
         if (stat != osOK)
+        {
+            self->dropped_rx_frame_count_.fetch_add(1, std::memory_order_relaxed);
             return HAL_BUSY;
+        }
     }
 
     // Now signal the task that messages are available
@@ -651,24 +654,23 @@ void CANDevice::HandleRxTrampoline(void* arg)
         if (osMessageQueueGet(rx_queue_, &msg, nullptr, osWaitForever) == osOK)
         {
             // Process the message
-            const CanCallback* cb = find_by_id(msg.can_id);
-            if (cb)
+            if (const CanCallback* cb = find_by_id(msg.can_id); cb)
             {
                 (*cb)(msg, this);
-                continue;
             }
-
-            cb = find_by_range(msg.can_id);
-            if (cb)
+            else if (cb = find_by_range(msg.can_id); cb)
             {
                 (*cb)(msg, this);
-                continue;
             }
-
-            if (allCallback_)
+            else if (allCallback_)
             {
                 allCallback_(msg, this);
             }
+            else
+            {
+                continue;
+            }
+            processed_messages_count_.fetch_add(1, std::memory_order_relaxed);
         }
     }
 }
@@ -687,8 +689,11 @@ void CANDevice::HandleTxTrampoline(void* arg)
 
         // Spinlock until a tx mailbox is empty
 #if defined(HAL_FDCAN_MODULE_ENABLED)
+        // TODO: use event/callback/sem so thread blocks when no slot in mailbox
         while (!HAL_FDCAN_GetTxFifoFreeLevel(hcan_))
-            ;
+        {
+            osDelay(1);
+        }
 
         FDCAN_TxHeaderTypeDef txHeader = {
             .Identifier = tx_msg.can_id,
@@ -705,6 +710,7 @@ void CANDevice::HandleTxTrampoline(void* arg)
 
         // Request HAL message send
         HAL_FDCAN_AddMessageToTxFifoQ(hcan_, &txHeader, tx_msg.data);
+        sent_messages_count_.fetch_add(1, std::memory_order_relaxed);
 #else
         while (!HAL_CAN_GetTxMailboxesFreeLevel(hcan_))
             ;
@@ -726,7 +732,7 @@ void CANDevice::HandleTxTrampoline(void* arg)
     }
 }
 
-HAL_StatusTypeDef CANDevice::Send(const CANFrame& msg)
+HAL_StatusTypeDef CANDevice::send(const CANFrame& msg)
 {
     if (osMessageQueuePut(tx_queue_, &msg, 0, TX_TIMEOUT) != osOK)
     {

--- a/resources/Drivers/SG_Drivers/flare/can_protocol.h
+++ b/resources/Drivers/SG_Drivers/flare/can_protocol.h
@@ -1,0 +1,43 @@
+//
+// Created by justin on 2/16/26.
+//
+
+#ifndef SOLARGATORSSTM32PROJECTS_CAN_PROTOCOL_H
+#define SOLARGATORSSTM32PROJECTS_CAN_PROTOCOL_H
+
+#include <cstdint>
+
+// holds enums used between boards for can messages
+namespace flare_can
+{
+
+enum class ArrayContactors : uint8_t
+{
+    BOTH_OPEN = 0,
+    PRECHARGE_CLOSED = 1,
+    MAIN_CLOSED = 2
+};
+
+enum class TurnSignals : uint8_t
+{
+    OFF = 0,
+    LEFT = 1,
+    RIGHT = 2,
+    HAZARDS = 3
+};
+
+enum class Direction : uint8_t
+{
+    REVERSE = 0,
+    FORWARD = 1
+};
+
+enum class MCPowerMode : uint8_t
+{
+    ECO = 0,
+    POWER = 1
+};
+
+}  // namespace flare_can
+
+#endif  //SOLARGATORSSTM32PROJECTS_CAN_PROTOCOL_H


### PR DESCRIPTION
some can driver refactoring as well as spliting rear vcu message into two since we can only send 8 byte messages

splits rear vcu message into two as shown on can map in teams
osDelay() when waiting on mailbox
naming refactors minor stuff
adds counters in can driver for messages recieved, messages sent, and dropped frames

Also sets up some recieving of new bms messages on steering wheel nad refactoring of steering state and rear vcu state, and added enums for can format in shared drivers folder

Should be tested on hardware first
